### PR TITLE
docs(spec): - clarify that prover_commit maps nonces, not witness - c…

### DIFF
--- a/draft-orru-zkproof-sigma-protocols.md
+++ b/draft-orru-zkproof-sigma-protocols.md
@@ -345,7 +345,7 @@ The group morphism `GroupMorphism` is initialized with
 
 A witness can be mapped to a group element via:
 
-    map(self, witness: [Scalar; num_scalars])
+    map(self, nonces: [Scalar; num_scalars])
 
     Inputs:
 
@@ -484,7 +484,7 @@ Let `H` be a hash object. The statement is encoded in a stateful hash object as 
     hasher.update_usize([cs.num_statements, cs.num_scalars])
     for equation in cs.equations:
       hasher.update_usize([equation.lhs, equation.rhs[0], equation.rhs[1]])
-    hasher.update(generators)
+    hasher.update(group_elements)
     iv = hasher.digest()
 
 In simpler terms, without stateful hash objects, this should correspond to the following:

--- a/draft-orru-zkproof-sigma-protocols.md
+++ b/draft-orru-zkproof-sigma-protocols.md
@@ -345,7 +345,7 @@ The group morphism `GroupMorphism` is initialized with
 
 A witness can be mapped to a group element via:
 
-    map(self, nonces: [Scalar; num_scalars])
+    map(self, scalars: [Scalar; num_scalars])
 
     Inputs:
 
@@ -484,7 +484,7 @@ Let `H` be a hash object. The statement is encoded in a stateful hash object as 
     hasher.update_usize([cs.num_statements, cs.num_scalars])
     for equation in cs.equations:
       hasher.update_usize([equation.lhs, equation.rhs[0], equation.rhs[1]])
-    hasher.update(group_elements)
+    hasher.update(generators)
     iv = hasher.digest()
 
 In simpler terms, without stateful hash objects, this should correspond to the following:


### PR DESCRIPTION
- update the prover commitment step to correctly use nonces rather than witness
- update the associate hashing procedure to use group_elements that is defined in the document as the rhs of the proof statement

Closes #37