### PR TITLE
refactor(fiat-shamir): clone hash state in prove/verify instead of resetting

### DIFF
--- a/poc/fiat_shamir.sage
+++ b/poc/fiat_shamir.sage
@@ -4,6 +4,7 @@ import struct
 from keccak import Keccak
 from sagelib.groups import Group
 from sagelib import groups
+import copy
 
 
 class DuplexSpongeInterface(ABC):
@@ -106,3 +107,6 @@ class KeccakDuplexSponge(DuplexSponge):
     def __init__(self, iv: bytes):
         self.permutation_state = KeccakPermutationState()
         super().__init__(iv)
+
+    def clone(self):
+        return copy.deepcopy(self)

--- a/poc/sigma_protocols.sage
+++ b/poc/sigma_protocols.sage
@@ -227,18 +227,22 @@ class NISigmaProtocol:
         self.codec = self.Codec()
 
     def prove(self, witness, rng):
+        hash_state = self.hash_state.clone()
+
         (prover_state, commitment) = self.sp.prover_commit(witness, rng)
-        self.codec.prover_message(self.hash_state, commitment)
-        challenge = self.codec.verifier_challenge(self.hash_state)
+        self.codec.prover_message(hash_state, commitment)
+        challenge = self.codec.verifier_challenge(hash_state)
         response = self.sp.prover_response(prover_state, challenge)
 
         assert self.sp.verifier(commitment, challenge, response)
         return self.sp.serialize_batchable(commitment, challenge, response)
 
     def verify(self, proof):
+        hash_state = self.hash_state.clone()
+
         commitment, response = self.sp.deserialize_batchable(proof)
-        self.codec.prover_message(self.hash_state, commitment)
-        challenge = self.codec.verifier_challenge(self.hash_state)
+        self.codec.prover_message(hash_state, commitment)
+        challenge = self.codec.verifier_challenge(hash_state)
         return self.sp.verifier(commitment, challenge, response)
 
 ### Codecs for the byte-oriented hash functions and elliptic curve groups


### PR DESCRIPTION
This prevents mutation of the base transcript state in `NISigmaProtocol`.
Now, `prove()` and `verify()` operate on a cloned `hash_state`, preserving
transcript determinism across multiple uses.

Also adds `.clone()` method to `KeccakDuplexSponge` using `copy.deepcopy`.

Fixes #36 