### PR TITLE
Mention equivocable commitments in discussion of deniability

### DIFF
--- a/draft-orru-zkproof-sigma-protocols.md
+++ b/draft-orru-zkproof-sigma-protocols.md
@@ -461,7 +461,7 @@ While theoretical analysis demonstrates that both soundness and zero-knowledge p
 
 The zero-knowledge proofs described are publicly verifiable (transferable) when they are constructed using the Fiat-Shamir transformation, as defined in the spec. This is because any party can perform the Fiat-Shamir transformation over the contents of the proof, to verify that the challenge was computed properly.
 
-The zero-knowlege proofs can be deniable if they are constructed with an interactive protocol, with an honest verifier and without transferable message authenticity. This is because given the contents of a proof, it is impossible to differentiate between an honestly generated or simulated proof. However, this construction is out of scope for this spec.
+Zero-knowlege proofs can be deniable if they are constructed with an interactive protocol (with an honest verifier, and without transferable message authenticity), or with certain non-interactive transformations (such as by using equivocable commitments). This is because given such a proof, it is impossible to differentiate between an honestly generated or simulated proof. However, these constructions are out of scope for this spec.
 
 # Post-Quantum Security Considerations
 


### PR DESCRIPTION
Addresses (part of) the concern in https://github.com/mmaker/draft-zkproof-sigma-protocols/issues/45.

Though I think the majority of the feedback arises from confusion of the relationship between the sigma protocol spec and the Fiat-Shamir spec (or a lack of knowledge of the existence of the Fiat-Shamir spec?), this PR addresses the feedback to mention other ways to construct sigma protocols other than through the Fiat-Shamir transform, and mentions equivocable commitments as another way to achieve deniability.